### PR TITLE
Managing transparency with contrastive learner

### DIFF
--- a/stylegan2_pytorch/stylegan2_pytorch.py
+++ b/stylegan2_pytorch/stylegan2_pytorch.py
@@ -529,7 +529,8 @@ class StyleGAN2(nn.Module):
         self.GE = Generator(image_size, latent_dim, network_capacity, transparent = transparent, attn_layers = attn_layers, no_const = no_const)
 
         # experimental contrastive loss discriminator regularization
-        self.D_cl = ContrastiveLearner(self.D, image_size, hidden_layer='flatten') if cl_reg else None
+		cl_dimensions = 4 if transparent else 3
+        self.D_cl = ContrastiveLearner(self.D, image_size, hidden_layer='flatten', channels_nb = cl_dimensions) if cl_reg else None
 
         # wrapper for augmenting all images going into the discriminator
         self.D_aug = AugWrapper(self.D, image_size)

--- a/stylegan2_pytorch/stylegan2_pytorch.py
+++ b/stylegan2_pytorch/stylegan2_pytorch.py
@@ -529,7 +529,7 @@ class StyleGAN2(nn.Module):
         self.GE = Generator(image_size, latent_dim, network_capacity, transparent = transparent, attn_layers = attn_layers, no_const = no_const)
 
         # experimental contrastive loss discriminator regularization
-		cl_dimensions = 4 if transparent else 3
+        cl_dimensions = 4 if transparent else 3
         self.D_cl = ContrastiveLearner(self.D, image_size, hidden_layer='flatten', channels_nb = cl_dimensions) if cl_reg else None
 
         # wrapper for augmenting all images going into the discriminator


### PR DESCRIPTION
Hello, trying to work with transparent images, I have faced a dimension error when willing to use :

 File "/home/ec2-user/.local/lib/python3.7/site-packages/contrastive_learner/contrastive_learner.py", line 128, in forward
    _ = self.net(x)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/stylegan2_pytorch/stylegan2_pytorch.py", line 504, in forward
    x = block(x)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/stylegan2_pytorch/stylegan2_pytorch.py", line 390, in forward
    res = self.conv_res(x)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/torch/nn/modules/conv.py", line 353, in forward
    return self._conv_forward(input, self.weight)
  File "/home/ec2-user/.local/lib/python3.7/site-packages/torch/nn/modules/conv.py", line 350, in _conv_forward
    self.padding, self.dilation, self.groups)
RuntimeError: Given groups=1, weight of size [16, 4, 1, 1], expected input[1, 3, 128, 128] to have 4 channels, but got 3 channels instead

I proposed to add a dynamic management of channels from the ContrastiveLearner class in the following pull request:
https://github.com/lucidrains/contrastive-learner/pull/1/commits/2b92123950d65af5bd0dd331db4a87bc64933e82

This one pull request uses the new `channels_nb` parameter to manage transparency.