### PR TITLE
Fix is_empty function

### DIFF
--- a/stylegan2_pytorch/stylegan2_pytorch.py
+++ b/stylegan2_pytorch/stylegan2_pytorch.py
@@ -119,7 +119,7 @@ def cast_list(el):
 
 def is_empty(t):
     if isinstance(t, torch.Tensor):
-        return t.nelement() <= 1
+        return t.nelement() == 1
     return t is None
 
 def raise_if_nan(t):

--- a/stylegan2_pytorch/stylegan2_pytorch.py
+++ b/stylegan2_pytorch/stylegan2_pytorch.py
@@ -119,7 +119,7 @@ def cast_list(el):
 
 def is_empty(t):
     if isinstance(t, torch.Tensor):
-        return t.nelement() == 1
+        return t.nelement() <= 1
     return t is None
 
 def raise_if_nan(t):

--- a/stylegan2_pytorch/stylegan2_pytorch.py
+++ b/stylegan2_pytorch/stylegan2_pytorch.py
@@ -119,7 +119,7 @@ def cast_list(el):
 
 def is_empty(t):
     if isinstance(t, torch.Tensor):
-        return t.nelement() == 0
+        return t.nelement() == 1
     return t is None
 
 def raise_if_nan(t):


### PR DESCRIPTION
Hey I found that there is a small bug in the is_empty function that the variable creatred by torch.empty() should return t.nelement() == 1. The bug will make the uninitialized self.pl_mean never get overwritten and cause the overflow issue sometimes.