### PR TITLE
reduce progress bar when steps reverted back to last checkpoint

### DIFF
--- a/stylegan2_pytorch/cli.py
+++ b/stylegan2_pytorch/cli.py
@@ -55,9 +55,12 @@ def run_training(rank, world_size, model_args, data, load_from, new, num_train_s
 
     model.set_data_src(data)
 
-    for _ in tqdm(range(num_train_steps - model.steps), initial = model.steps, total = num_train_steps, mininterval=10., desc=f'{name}<{data}>'):
+    progress_bar = tqdm(initial = model.steps, total = num_train_steps, mininterval=10., desc=f'{name}<{data}>')
+    while model.steps < num_train_steps:
         retry_call(model.train, tries=3, exceptions=NanException)
-        if is_main and _ % 50 == 0:
+        progress_bar.n = model.steps
+        progress_bar.refresh()
+        if is_main and model.steps % 50 == 0:
             model.print_log()
 
     model.save(model.checkpoint_num)


### PR DESCRIPTION
Fix bug where positive progress is displayed, even when the reality is an infinite crash loop caused by NanException thrown before Checkpoint 1.

Example: save_every = 1000, NanException is thrown around iteration 700. Steps will keep increasing to the thousands and progress bar displays the training getting closer to completion, but the model never gets close to converging because of the infinite crash loop before Checkpoint 1.

## Simulating NanException

To quickly simulate NanException being thrown, temporarily change the line:

https://github.com/lucidrains/stylegan2-pytorch/blob/624e3deb484bea46c58c89bf2c2109397bdc87ab/stylegan2_pytorch/stylegan2_pytorch.py#L1128

to

```
        if (self.steps > 1 and self.steps % 51 == 0) or any(torch.isnan(l) for l in (total_gen_loss, total_disc_loss)):
```