### PR TITLE
Add parameters to color augments & separate out into separate augments.

### DIFF
--- a/stylegan2_pytorch/diff_augment.py
+++ b/stylegan2_pytorch/diff_augment.py
@@ -46,7 +46,7 @@ def rand_translation(x, ratio=0.125):
     grid_x = torch.clamp(grid_x + translation_x + 1, 0, x.size(2) + 1)
     grid_y = torch.clamp(grid_y + translation_y + 1, 0, x.size(3) + 1)
     x_pad = F.pad(x, [1, 1, 1, 1, 0, 0, 0, 0])
-    x = x_pad.permute(0, 2, 3, 1).contiguous()[grid_batch, grid_x, grid_y].permute(0, 3, 1, 2).contiguous(memory_format = torch.contiguous_format)
+    x = x_pad.permute(0, 2, 3, 1).contiguous()[grid_batch, grid_x, grid_y].permute(0, 3, 1, 2)
     return x
 
 def rand_offset(x, ratio=1, ratio_h=1, ratio_v=1):


### PR DESCRIPTION
I've found it useful to have a color augment that isn't quite as severe with its changes for training, so I added a `scale` parameter to the color augmentation functions and added the `lightcolor` augment, which isn't so extreme with its augmentations. I've set the parameters for the `color` augment so that it should perform exactly the same as before this change.

In addition, issue #247 requests that the color augments (specifically brightness) be separated out into a separate augmentation, which I've done for `brightness`, `saturation`, and `contrast` (and also included `light` variants of each)